### PR TITLE
19 consume dt

### DIFF
--- a/assets/agents/DataconsumerAgent.py
+++ b/assets/agents/DataconsumerAgent.py
@@ -81,3 +81,9 @@ class DataconsumerAgent(AgentBase):
         DT = pool_agent.datatoken
 
         self._wallet.buyDT(pool, DT, DT_buy_amt, max_OCEAN_allow)
+
+        assert self.DT(DT) == DT_buy_amt
+
+        controller = pool.controller_address()
+
+        self._wallet.transferDT(controller, DT, DT_buy_amt)

--- a/assets/agents/DataconsumerAgent.py
+++ b/assets/agents/DataconsumerAgent.py
@@ -82,30 +82,17 @@ class DataconsumerAgent(AgentBase):
         pool = pool_agent.pool
         DT = pool_agent.datatoken
 
-        OCEAN_address = globaltokens.OCEAN_address()
-        DT_address = pool_agent.datatoken_address
-
-        pool_DT_balance_base = pool.getBalance_base(DT_address)
-        pool_OCEAN_balance_base = pool.getBalance_base(OCEAN_address)
-        pool_DT_weight_base = pool.getDenormalizedWeight_base(DT_address)
-        pool_OCEAN_weight_base = pool.getDenormalizedWeight_base(OCEAN_address)
-        pool_swapFee_base = pool.getSwapFee_base()
-        DT_amount_out_base = toBase18(DT_buy_amt)
-
-        OCEANamountIn_base = pool.calcInGivenOut_base(
-            tokenBalanceIn_base=pool_OCEAN_balance_base,
-            tokenWeightIn_base=pool_OCEAN_weight_base,
-            tokenBalanceOut_base=pool_DT_balance_base,
-            tokenWeightOut_base=pool_DT_weight_base,
-            tokenAmountOut_base=DT_amount_out_base,
-            swapFee_base=pool_swapFee_base)
-
-        OCEANamountIn = fromBase18(OCEANamountIn_base)
-        OCEAN_spend = OCEANamountIn * DT_buy_amt
-
+        DT_before = self.DT(DT)
+        OCEAN_before = self.OCEAN()
+        
         self._wallet.buyDT(pool, DT, DT_buy_amt, max_OCEAN_allow)
+        DT_after = self.DT(DT)
+        OCEAN_after = self.OCEAN()
+        
+        assert self.DT(DT) == (DT_before + DT_buy_amt)
+        assert OCEAN_after < OCEAN_before
 
-        assert self.DT(DT) == DT_buy_amt
+        OCEAN_spend = OCEAN_before - OCEAN_after
 
         return pool_agent, OCEAN_spend
 

--- a/assets/agents/DataconsumerAgent.py
+++ b/assets/agents/DataconsumerAgent.py
@@ -79,7 +79,7 @@ class DataconsumerAgent(AgentBase):
 
     def _buyDT(self, state):
         """Buy dataset"""
-        DT_buy_amt = 1.0
+        DT_buy_amt = 1.0 # magic number 
         max_OCEAN_allow = self.OCEAN()
         OCEANtoken = globaltokens.OCEANtoken()
 
@@ -98,10 +98,10 @@ class DataconsumerAgent(AgentBase):
 
     def _consumeDT(self, state, pool_agent):
         """Consume dataset"""
-        DT_buy_amt = 1.0
+        DT_consume_amt = 1.0 # magic number 
         DT = pool_agent.datatoken
 
         controller = pool_agent.controller_address
         controller_agent = self._searchAgentAddress(state, controller)
 
-        self._wallet.transferDT(controller_agent._wallet, DT, DT_buy_amt)
+        self._wallet.transferDT(controller_agent._wallet, DT, DT_consume_amt)

--- a/assets/agents/DataconsumerAgent.py
+++ b/assets/agents/DataconsumerAgent.py
@@ -20,12 +20,12 @@ class DataconsumerAgent(AgentBase):
     def takeStep(self, state) -> None:
         self._s_since_buy += state.ss.time_step
         
-        if self._doBuyDT(state):
+        if self._doBuyAndConsumeDT(state):
             self._s_since_buy = 0
             pool_agent, OCEAN_spend = self._buyDT(state)
             self._consumeDT(state, pool_agent, OCEAN_spend)
 
-    def _doBuyDT(self, state):
+    def _doBuyAndConsumeDT(self, state):
         cand_pool_agents = self._candPoolAgents(state)
         if not cand_pool_agents:
             return False

--- a/assets/agents/DataconsumerAgent.py
+++ b/assets/agents/DataconsumerAgent.py
@@ -69,18 +69,9 @@ class DataconsumerAgent(AgentBase):
                 
         return cand_pool_agents
 
-    def _searchAgentAddress(self, state, search_address):
-        """Search all agents by eth address"""
-        all_agents = state.agents.values()
-        for agent in all_agents:
-            address = agent._wallet._address
-
-            if address == search_address:
-                return agent
-
     def _buyDT(self, state):
         """Buy dataset"""
-        DT_buy_amt = 1.0 # magic number 
+        DT_buy_amt = 1.0 # buy just enough to consume once
         max_OCEAN_allow = self.OCEAN()
         OCEANtoken = globaltokens.OCEANtoken()
 
@@ -120,11 +111,11 @@ class DataconsumerAgent(AgentBase):
 
     def _consumeDT(self, state, pool_agent, OCEAN_spend):
         """Consume dataset"""
-        DT_consume_amt = 1.0 # magic number 
+        DT_consume_amt = 1.0 # consume just once
         DT = pool_agent.datatoken
 
-        controller = pool_agent.controller_address
-        controller_agent = self._searchAgentAddress(state, controller)
+        controller_agent = state.agents.agentByAddress(
+            pool_agent.controller_address)
 
         self._wallet.transferDT(controller_agent._wallet, DT, DT_consume_amt)
 

--- a/assets/agents/DataconsumerAgent.py
+++ b/assets/agents/DataconsumerAgent.py
@@ -15,7 +15,7 @@ class DataconsumerAgent(AgentBase):
         
         self._s_since_buy = 0
         self._s_between_buys = 3 * constants.S_PER_DAY #magic number
-        self.OCEAN_profit = 0.2 # magic number 
+        self.profit_margin_on_consume = 0.2 # magic number 
         
     def takeStep(self, state) -> None:
         self._s_since_buy += state.ss.time_step
@@ -119,5 +119,5 @@ class DataconsumerAgent(AgentBase):
 
         self._wallet.transferDT(controller_agent._wallet, DT, DT_consume_amt)
 
-        OCEAN_returned = OCEAN_spend * (1 + self.OCEAN_profit)
+        OCEAN_returned = OCEAN_spend * (1 + self.profit_margin_on_consume)
         self.receiveOCEAN(OCEAN_returned)

--- a/assets/agents/DataconsumerAgent.py
+++ b/assets/agents/DataconsumerAgent.py
@@ -100,7 +100,7 @@ class DataconsumerAgent(AgentBase):
         pool_OCEAN_weight_base = pool.getDenormalizedWeight_base(OCEAN_address)
         pool_swapFee_base = pool.getSwapFee_base()
 
-        DT_amount_out_base = toBase18(1.0)
+        DT_amount_out_base = toBase18(DT_buy_amt)
 
         OCEANamountIn_base = fromBase18(pool.calcInGivenOut_base(
             tokenBalanceIn_base=pool_OCEAN_balance_base,

--- a/assets/agents/DataconsumerAgent.py
+++ b/assets/agents/DataconsumerAgent.py
@@ -21,7 +21,8 @@ class DataconsumerAgent(AgentBase):
         
         if self._doBuyDT(state):
             self._s_since_buy = 0
-            self._buyDT(state)
+            pool_agent = self._buyDT(state)
+            self._consumeDT(state, pool_agent)
 
     def _doBuyDT(self, state):
         cand_pool_agents = self._candPoolAgents(state)
@@ -77,7 +78,7 @@ class DataconsumerAgent(AgentBase):
                 return agent
 
     def _buyDT(self, state):
-        """Buy, and consume dataset"""
+        """Buy dataset"""
         DT_buy_amt = 1.0
         max_OCEAN_allow = self.OCEAN()
         OCEANtoken = globaltokens.OCEANtoken()
@@ -92,6 +93,13 @@ class DataconsumerAgent(AgentBase):
         self._wallet.buyDT(pool, DT, DT_buy_amt, max_OCEAN_allow)
 
         assert self.DT(DT) == DT_buy_amt
+
+        return pool_agent
+
+    def _consumeDT(self, state, pool_agent):
+        """Consume dataset"""
+        DT_buy_amt = 1.0
+        DT = pool_agent.datatoken
 
         controller = pool_agent.controller_address
         controller_agent = self._searchAgentAddress(state, controller)

--- a/assets/agents/DataconsumerAgent.py
+++ b/assets/agents/DataconsumerAgent.py
@@ -67,6 +67,15 @@ class DataconsumerAgent(AgentBase):
                 
         return cand_pool_agents
 
+    def _searchAgentAddress(self, state, search_address):
+        """Search all agents by eth address"""
+        all_agents = state.agents.values()
+        for agent in all_agents:
+            address = agent._wallet._address
+
+            if address == search_address:
+                return agent
+
     def _buyDT(self, state):
         """Buy, and consume dataset"""
         DT_buy_amt = 1.0
@@ -85,5 +94,6 @@ class DataconsumerAgent(AgentBase):
         assert self.DT(DT) == DT_buy_amt
 
         controller = pool_agent.controller_address
+        controller_agent = self._searchAgentAddress(state, controller)
 
-        self._wallet.transferDT(controller, DT, DT_buy_amt)
+        self._wallet.transferDT(controller_agent._wallet, DT, DT_buy_amt)

--- a/assets/agents/DataconsumerAgent.py
+++ b/assets/agents/DataconsumerAgent.py
@@ -84,6 +84,6 @@ class DataconsumerAgent(AgentBase):
 
         assert self.DT(DT) == DT_buy_amt
 
-        controller = pool.controller_address()
+        controller = pool_agent.controller_address
 
         self._wallet.transferDT(controller, DT, DT_buy_amt)

--- a/assets/agents/PoolAgent.py
+++ b/assets/agents/PoolAgent.py
@@ -13,6 +13,7 @@ class PoolAgent(AgentBase):
         
         self._dt_address = self._datatokenAddress()
         self._dt = datatoken.Datatoken(self._dt_address)
+        self._controller_address = self._controllerAddress()
 
     @property
     def pool(self) -> bpool.BPool:
@@ -38,3 +39,10 @@ class PoolAgent(AgentBase):
             if addr != OCEAN_addr:
                 return addr
         raise AssertionError("should never get here")
+
+    @property
+    def controller_address(self) -> str:
+        return self._controller_address
+
+    def _controllerAddress(self):
+        return self._pool.getController() 

--- a/assets/agents/test/test_DataconsumerAgent.py
+++ b/assets/agents/test/test_DataconsumerAgent.py
@@ -77,6 +77,6 @@ def test_buyDT(alice_info):
     # we model lag from consume to value creation simply by a delay between buys
     assert alice_agent.DT(dt) == 80.0
     agent._consumeDT(state, pool_agent, OCEAN_spend)
-    assert agent.OCEAN() == 1000.0 + OCEAN_spend * agent.OCEAN_profit
+    assert agent.OCEAN() == 1000.0 + OCEAN_spend * agent.profit_margin_on_consume
     assert agent.DT(dt) == 0.0
     assert alice_agent.DT(dt) == 81.0

--- a/assets/agents/test/test_DataconsumerAgent.py
+++ b/assets/agents/test/test_DataconsumerAgent.py
@@ -54,6 +54,15 @@ def test_buyDT(alice_pool, alice_agent):
     assert agent._candPoolAgents(state) #have useful pools
     assert agent._doBuyDT(state)
 
-    agent._buyDT(state)
     dt = state.agents["pool1"].datatoken
+    assert agent.DT(dt) == 0.0
+    pool_agent = agent._buyDT(state)
     assert agent.DT(dt) == 1.0
+
+    # consume
+    controller = pool_agent.controller_address
+    assert agent._searchAgentAddress(state, controller)
+    assert alice_agent.DT(dt) == 80.0
+    agent._consumeDT(state, pool_agent)
+    assert agent.DT(dt) == 0.0
+    assert alice_agent.DT(dt) == 81.0

--- a/assets/agents/test/test_DataconsumerAgent.py
+++ b/assets/agents/test/test_DataconsumerAgent.py
@@ -2,6 +2,7 @@ import pytest
 
 from assets.agents.PoolAgent import PoolAgent
 from assets.agents.DataconsumerAgent import DataconsumerAgent
+from assets.agents.PublisherAgent import PublisherAgent
 from engine.AgentDict import AgentDict
 from util.constants import S_PER_HOUR
 
@@ -9,6 +10,8 @@ class MockSS:
     def __init__(self):
         #seconds per tick
         self.time_step: int = S_PER_HOUR
+        self.pool_weight_DT: float = 1.0
+        self.pool_weight_OCEAN: float = 1.0
 
 class MockState:
     def __init__(self):
@@ -37,9 +40,11 @@ def test_doBuyDT(alice_pool):
     assert agent._candPoolAgents(state) #have useful pools
     assert agent._doBuyDT(state)
 
-def test_buyDT(alice_pool):
+def test_buyDT(alice_pool, alice_agent):
     state = MockState()
-    agent = DataconsumerAgent("agent1",USD=0.0,OCEAN=1000.0) 
+    state.addAgent(alice_agent)
+    agent = DataconsumerAgent("con1", USD=0.0, OCEAN=1000.0) 
+    state.addAgent(agent)
 
     agent._s_since_buy += agent._s_between_buys
 

--- a/assets/agents/test/test_DataconsumerAgent.py
+++ b/assets/agents/test/test_DataconsumerAgent.py
@@ -63,15 +63,21 @@ def test_buyDT(alice_info):
     assert agent._candPoolAgents(state) #have useful pools
     assert agent._doBuyDT(state)
 
+    # buyDT
     dt = state.agents["pool1"].datatoken
+    assert agent.OCEAN() == 1000.0
     assert agent.DT(dt) == 0.0
-    pool_agent = agent._buyDT(state)
+    pool_agent, OCEAN_spend = agent._buyDT(state)
+    assert agent.OCEAN() == 1000.0 - OCEAN_spend
     assert agent.DT(dt) == 1.0
 
-    # consume
+    # consumeDT
     controller = pool_agent.controller_address
     assert agent._searchAgentAddress(state, controller)
+
+    # we model lag from consume to value creation simply by a delay between buys
     assert alice_agent.DT(dt) == 80.0
-    agent._consumeDT(state, pool_agent)
+    agent._consumeDT(state, pool_agent, OCEAN_spend)
+    assert agent.OCEAN() == 1000.0 + OCEAN_spend * agent.OCEAN_profit
     assert agent.DT(dt) == 0.0
     assert alice_agent.DT(dt) == 81.0

--- a/assets/agents/test/test_DataconsumerAgent.py
+++ b/assets/agents/test/test_DataconsumerAgent.py
@@ -3,6 +3,7 @@ import pytest
 from assets.agents.PoolAgent import PoolAgent
 from assets.agents.DataconsumerAgent import DataconsumerAgent
 from assets.agents.PublisherAgent import PublisherAgent
+from engine.AgentBase import AgentBase
 from engine.AgentDict import AgentDict
 from util.constants import S_PER_HOUR
 
@@ -19,6 +20,10 @@ class MockState:
         self.ss = MockSS()
     def addAgent(self, agent):
         self.agents[agent.name] = agent
+
+class MockAgent(AgentBase):
+    def takeStep(self, state):
+        pass
 
 # @pytest.mark.skip(reason="TODO FIXME")
 def test_doBuyDT(alice_pool):
@@ -40,11 +45,15 @@ def test_doBuyDT(alice_pool):
     assert agent._candPoolAgents(state) #have useful pools
     assert agent._doBuyDT(state)
 
-def test_buyDT(alice_pool, alice_agent):
+def test_buyDT(alice_info):
     state = MockState()
+    alice_agent = MockAgent("agent1", USD=0.0, OCEAN=0.0)
+    alice_agent._wallet = alice_info.agent_wallet
     state.addAgent(alice_agent)
     agent = DataconsumerAgent("con1", USD=0.0, OCEAN=1000.0) 
     state.addAgent(agent)
+
+    alice_pool = alice_info.pool
 
     agent._s_since_buy += agent._s_between_buys
 

--- a/assets/agents/test/test_DataconsumerAgent.py
+++ b/assets/agents/test/test_DataconsumerAgent.py
@@ -26,7 +26,7 @@ class MockAgent(AgentBase):
         pass
 
 # @pytest.mark.skip(reason="TODO FIXME")
-def test_doBuyDT(alice_pool):
+def test_doBuyAndConsumeDT(alice_pool):
     state = MockState()
 
     agent = DataconsumerAgent("agent1",USD=0.0,OCEAN=1000.0)
@@ -34,16 +34,16 @@ def test_doBuyDT(alice_pool):
     assert agent._s_since_buy == 0
     assert agent._s_between_buys > 0
 
-    assert not agent._doBuyDT(state)
+    assert not agent._doBuyAndConsumeDT(state)
 
     agent._s_since_buy += agent._s_between_buys
     assert not state.agents.filterToPool().values()
-    assert not agent._doBuyDT(state) #still no, since no pools
+    assert not agent._doBuyAndConsumeDT(state) #still no, since no pools
 
     state.agents["pool1"] = PoolAgent("pool1", alice_pool)
     assert state.agents.filterToPool().values() #have pools
     assert agent._candPoolAgents(state) #have useful pools
-    assert agent._doBuyDT(state)
+    assert agent._doBuyAndConsumeDT(state)
 
 def test_buyDT(alice_info):
     state = MockState()
@@ -61,7 +61,7 @@ def test_buyDT(alice_info):
 
     assert state.agents.filterToPool().values() #have pools
     assert agent._candPoolAgents(state) #have useful pools
-    assert agent._doBuyDT(state)
+    assert agent._doBuyAndConsumeDT(state)
 
     # buyDT
     dt = state.agents["pool1"].datatoken

--- a/assets/agents/test/test_DataconsumerAgent.py
+++ b/assets/agents/test/test_DataconsumerAgent.py
@@ -72,8 +72,7 @@ def test_buyDT(alice_info):
     assert agent.DT(dt) == 1.0
 
     # consumeDT
-    controller = pool_agent.controller_address
-    assert agent._searchAgentAddress(state, controller)
+    assert state.agents.agentByAddress(pool_agent.controller_address)
 
     # we model lag from consume to value creation simply by a delay between buys
     assert alice_agent.DT(dt) == 80.0

--- a/assets/agents/test/test_DataconsumerAgent.py
+++ b/assets/agents/test/test_DataconsumerAgent.py
@@ -25,7 +25,6 @@ class MockAgent(AgentBase):
     def takeStep(self, state):
         pass
 
-# @pytest.mark.skip(reason="TODO FIXME")
 def test_doBuyAndConsumeDT(alice_pool):
     state = MockState()
 
@@ -45,38 +44,38 @@ def test_doBuyAndConsumeDT(alice_pool):
     assert agent._candPoolAgents(state) #have useful pools
     assert agent._doBuyAndConsumeDT(state)
 
-def test_buyDT(alice_info):
+def test_buyAndConsumeDT(alice_info):
     state = MockState()
-    alice_agent = MockAgent("agent1", USD=0.0, OCEAN=0.0)
-    alice_agent._wallet = alice_info.agent_wallet
-    state.addAgent(alice_agent)
-    agent = DataconsumerAgent("con1", USD=0.0, OCEAN=1000.0) 
-    state.addAgent(agent)
 
-    alice_pool = alice_info.pool
+    publisher_agent = MockAgent("agent1", USD=0.0, OCEAN=0.0)
+    publisher_agent._wallet = alice_info.agent_wallet
+    state.addAgent(publisher_agent)
 
-    agent._s_since_buy += agent._s_between_buys
+    OCEAN_before = 1000.0
+    consumer_agent = DataconsumerAgent("consumer1", USD=0.0, OCEAN=OCEAN_before)
+    consumer_agent._s_since_buy += consumer_agent._s_between_buys
+    state.addAgent(consumer_agent)
 
-    state.agents["pool1"] = PoolAgent("pool1", alice_pool)
+    pool_agent = PoolAgent("pool1", alice_info.pool)
+    state.addAgent(pool_agent)
 
     assert state.agents.filterToPool().values() #have pools
-    assert agent._candPoolAgents(state) #have useful pools
-    assert agent._doBuyAndConsumeDT(state)
+    assert consumer_agent._candPoolAgents(state) #have useful pools
+    assert consumer_agent._doBuyAndConsumeDT(state)
 
-    # buyDT
+    # buyAndConsumeDT
     dt = state.agents["pool1"].datatoken
-    assert agent.OCEAN() == 1000.0
-    assert agent.DT(dt) == 0.0
-    pool_agent, OCEAN_spend = agent._buyDT(state)
-    assert agent.OCEAN() == 1000.0 - OCEAN_spend
-    assert agent.DT(dt) == 1.0
+
+    assert consumer_agent.OCEAN() == OCEAN_before
+    assert consumer_agent.DT(dt) == 0.0
+    
+    OCEAN_spend = consumer_agent._buyAndConsumeDT(state)
+    
+    OCEAN_after = consumer_agent.OCEAN()
+    OCEAN_gained = OCEAN_spend * (1.0 + consumer_agent.profit_margin_on_consume)
+    assert OCEAN_after == (OCEAN_before - OCEAN_spend + OCEAN_gained)
+    
+    assert consumer_agent.DT(dt) == 0.0 #bought 1.0, then consumed it
 
     # consumeDT
     assert state.agents.agentByAddress(pool_agent.controller_address)
-
-    # we model lag from consume to value creation simply by a delay between buys
-    assert alice_agent.DT(dt) == 80.0
-    agent._consumeDT(state, pool_agent, OCEAN_spend)
-    assert agent.OCEAN() == 1000.0 + OCEAN_spend * agent.profit_margin_on_consume
-    assert agent.DT(dt) == 0.0
-    assert alice_agent.DT(dt) == 81.0

--- a/engine/AgentBase.py
+++ b/engine/AgentBase.py
@@ -29,6 +29,12 @@ class AgentBase(ABC, StrMixin):
         pass
 
     #=======================================================================
+    #core
+    @property
+    def address(self) -> str:
+        return self._wallet._address
+        
+    #=======================================================================
     #USD-related
     def USD(self) -> float:
         return self._wallet.USD() 

--- a/engine/AgentDict.py
+++ b/engine/AgentDict.py
@@ -36,4 +36,10 @@ class AgentDict(dict):
         return AgentDict({agent.name : agent
                           for agent in self.values()
                           if isinstance(agent, _class)})
-    
+
+    def agentByAddress(self, address):
+        for agent in self.values():
+            if agent.address == address:
+                return agent
+        return None
+

--- a/engine/AgentWallet.py
+++ b/engine/AgentWallet.py
@@ -227,11 +227,7 @@ class AgentWallet:
             raise ValueError("transfer amt (%s) exceeds DT holdings (%s)"
                              % (fromBase18(amt_base), fromBase18(DT_base)))
 
-        DT.transfer(dst_address, amt_base, self._web3wallet)
-
-        dst_wallet.DT(DT) += amt
-        self.resetCachedInfo()
-        dst_wallet.resetCachedInfo()     
+        DT.transfer(dst_address, amt_base, self._web3wallet)     
 
     #===================================================================
     def __str__(self) -> str:

--- a/engine/AgentWallet.py
+++ b/engine/AgentWallet.py
@@ -205,6 +205,34 @@ class AgentWallet:
             from_wallet=self._web3wallet)
         self.resetCachedInfo()
 
+    def transferDT(self, dst_wallet, DT: datatoken.Datatoken, amt: float) -> None:
+        assert isinstance(dst_wallet, AgentWallet) or \
+            isinstance(dst_wallet, BurnWallet)
+        dst_address = dst_wallet._address
+
+        amt_base = toBase18(amt)
+        assert amt_base >= 0
+        if amt_base == 0:
+            return
+
+        DT_base = self._DT_base(DT)
+        if DT_base == 0:
+            raise ValueError("no data tokens to transfer")        
+
+        tol = 1e-12
+        if (1.0 - tol) <= amt/fromBase18(DT_base) <= (1.0 + tol):
+            amt_base = DT_base
+
+        if amt_base > DT_base:
+            raise ValueError("transfer amt (%s) exceeds DT holdings (%s)"
+                             % (fromBase18(amt_base), fromBase18(DT_base)))
+
+        DT.transfer(dst_address, amt_base, self._web3wallet)
+
+        dst_wallet.DT(DT) += amt
+        self.resetCachedInfo()
+        dst_wallet.resetCachedInfo()     
+
     #===================================================================
     def __str__(self) -> str:
         s = []

--- a/engine/test/test_AgentBase.py
+++ b/engine/test/test_AgentBase.py
@@ -16,6 +16,8 @@ def testInit():
     assert agent.USD() == 1.1
     assert agent.OCEAN() == 1.2
     assert "MyTestAgent" in str(agent)
+    assert isinstance(agent.address, str)
+    assert agent.address == agent._wallet._address
 
 @enforce_types
 def testReceiveAndSend():

--- a/engine/test/test_AgentDict.py
+++ b/engine/test/test_AgentDict.py
@@ -47,4 +47,20 @@ def test2():
     assert not d.filterToDataconsumer()
     
     assert len(d.filterByClass(FooAgent)) == 1
+
+@enforce_types
+def test_agentByAddress():
+    class FooAgent:
+        def __init__(self, name, address):
+            self.name = name
+            self.address = address
+
+    d = AgentDict(
+        {'foo1': FooAgent('foo1', 'address 111'),
+         'foo2': FooAgent('foo2', 'address 222')
+        })
+
+    assert d.agentByAddress('address 111').address == 'address 111'
+    assert d.agentByAddress('address 222').address == 'address 222'
+    assert d.agentByAddress('address foo') is None
     


### PR DESCRIPTION
Fixes #19 

Let me know if you think getting the controller address of the pool (and searching through all agents for a match) can be improved. Another option might be to store this as a parameter of the pool when it's created. 

Also, passing information between buyDT and consumeDT might be a bit messy. The reason I separated these originally was for testing. 

Maybe we can also refactor code for calculating OCEANamountIn_base.