### PR TITLE
New Pull Request for Issue #81 ( live ganache logging and CI )

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -2,9 +2,9 @@ name: MyPy Static Typechecking
 
 on:
   push:
-    branches: [ ganachepy_background_toggle ]
+    branches: [ main ]
   pull_request:
-    branches: [ ganachepy_background_toggle ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -2,9 +2,9 @@ name: MyPy Static Typechecking
 
 on:
   push:
-    branches: [ action_tests ]
+    branches: [ ganachepy_background_toggle ]
   pull_request:
-    branches: [ action_tests ]
+    branches: [ ganachepy_background_toggle ]
 
 jobs:
   build:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,9 +2,9 @@ name: Unit Testing
 
 on:
   push:
-    branches: [ action_tests ]
+    branches: [ main ]
   pull_request:
-    branches: [ action_tests ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -43,7 +43,7 @@ jobs:
           
       - name: Executing Python Ganache script
         run: |
-          nohup python3 ganache.py
+          nohup python3 ganache.py --run-in-background
 
       - name: Check Node version on this machine.
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,9 +2,9 @@ name: Unit Testing
 
 on:
   push:
-    branches: [ main ]
+    branches: [ ganachepy_background_toggle ]
   pull_request:
-    branches: [ main ]
+    branches: [ ganachepy_background_toggle ]
 
 jobs:
   build:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,9 +2,9 @@ name: Unit Testing
 
 on:
   push:
-    branches: [ ganachepy_background_toggle ]
+    branches: [ main ]
   pull_request:
-    branches: [ ganachepy_background_toggle ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 # TokenSPICE: EVM Agent-Based Token Simulator 🐟🌪️
 
 <div align="center">
-<img alt="Pytest Unit Testing" src="https://github.com/JohannSuarez/tokenspice/actions/workflows/pytest.yml/badge.svg">
+<img alt="Pytest Unit Testing" src="https://github.com/tokenspice/tokenspice/actions/workflows/pytest.yml/badge.svg">
 
-<img alt="MyPy Static Type Checking" src="https://github.com/JohannSuarez/tokenspice/actions/workflows/mypy.yml/badge.svg">
+<img alt="MyPy Static Type Checking" src="https://github.com/tokenspice/tokenspice/actions/workflows/mypy.yml/badge.svg">
 </div>
 
 TokenSPICE simulates tokenized ecosystems via an agent-based approach, with EVM in-the-loop.

--- a/ganache.py
+++ b/ganache.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python
 
 import eth_utils
+import argparse
 import os
 
 from web3tools.web3util import confFileValue
+
+# Argument parsing for hiding ganache.py in background
+parser = argparse.ArgumentParser()
+parser.add_argument("--run-in-background", action='store_true',
+                    help="Run ganache on background for further use of current terminal.")
+args = parser.parse_args()
 
 # Port in ganache_url must match ganache-cli call
 port_number = '8545'
@@ -21,5 +28,11 @@ factory_deployer_private_key = confFileValue(
 # launch ganache-cli and give each private account 100 eth.
 amount_eth = 100
 amount_wei = eth_utils.to_wei(amount_eth, 'ether')
-os.system(
-    f'ganache-cli --port {port_number} --gasLimit 10000000000 --gasPrice 1 ---hardfork istanbul --account="{alice_private_key},{amount_wei}" --account="{bob_private_key},{amount_wei}" --account="{factory_deployer_private_key},{amount_wei}" &')
+
+ganache_command = f'ganache-cli --port {port_number} --gasLimit 10000000000 --gasPrice 1 ---hardfork istanbul --account="{alice_private_key},{amount_wei}" --account="{bob_private_key},{amount_wei}" --account="{factory_deployer_private_key},{amount_wei}"'
+
+
+if args.run_in_background:
+    os.system(ganache_command + '&')
+else:
+    os.system(ganache_command)


### PR DESCRIPTION
For #81.

Changes:

- **ganache.py** - Implemented optional argument --run-in-background, so by default ganache doesn't get put in the background.

- .**github/workflows/pytest.ym**l - Adjusted workflow so it runs ganache.py with --run-in-background and it executes when something is pushed or pull requested to main. 

- **.github/workflows/mypy.yml** -  Adjusted workflow so  it executes when something is pushed or pull requested to main. 

- **README.MD** - Previous badges referenced my local fork's experimental branch. This edit should have the main's README.md reference the workflow results of its own branch in this repo.