### PR TITLE
Pull Request For Issue #26 ( Code Coverage on README.md )

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -78,6 +78,9 @@ jobs:
         run: |
           pytest assets/agents/test/test_DataconsumerAgent.py
 
-      - name: Run Entire Suite of Tests 
+      - name: Run Entire Suite of Tests Along With Code Coverage Analysis
         run: |
-          pytest
+          coverage run -m pytest
+          coverage xml
+          export CODACY_PROJECT_TOKEN=${{ secrets.CODACY_PROJECT_TOKEN }}
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage.xml

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,4 +1,4 @@
-name: Unit Testing
+name: Unit Testing and Code Coverage
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -3,10 +3,17 @@
 # TokenSPICE: EVM Agent-Based Token Simulator 🐟🌪️
 
 <div align="center">
-<img alt="Pytest Unit Testing" src="https://github.com/tokenspice/tokenspice/actions/workflows/pytest.yml/badge.svg">
 
+<!-- Pytest and MyPy Badges -->
+<img alt="Pytest Unit Testing" src="https://github.com/tokenspice/tokenspice/actions/workflows/pytest.yml/badge.svg">
 <img alt="MyPy Static Type Checking" src="https://github.com/tokenspice/tokenspice/actions/workflows/mypy.yml/badge.svg">
+
+<!-- Codacy Badges -->
+<p><a href="https://www.codacy.com/gh/JohannSuarez/tokenspice/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=JohannSuarez/tokenspice&amp;utm_campaign=Badge_Coverage"><img src="https://app.codacy.com/project/badge/Coverage/d1710b2e0daa474ba961ccbc9f38e6a9" alt="Codacy Badge"></a>
+<a href="https://www.codacy.com/gh/JohannSuarez/tokenspice/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=JohannSuarez/tokenspice&amp;utm_campaign=Badge_Grade"><img src="https://app.codacy.com/project/badge/Grade/d1710b2e0daa474ba961ccbc9f38e6a9" alt="Codacy Badge"></a></p>
+
 </div>
+
 
 TokenSPICE simulates tokenized ecosystems via an agent-based approach, with EVM in-the-loop.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 [pytest]
 filterwarnings =
     ignore::DeprecationWarning
+
+[coverage:run]
+omit=*/site-packages/*,*/tests/*, */.eggs/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,7 @@ eth-keys
 eth-utils
 pandas
 matplotlib
+coverage
+codacy-coverage
 
 


### PR DESCRIPTION
**Proposed changes:**

- **requirements.txt**  - adding coverage.py, and  codacy-coverage.

- **pytest.ini** - New rules for coverage.py, telling it not to report coverage on site packages ( the modules we pip install) , because we're only interested in the coverage of the modules actually inside the repo.

- **.github/workflows/pytest.yml** - Pytest will run the entire suite of tests along with coverage.py now, and will send the report to Codacy. This is how we get the badge.

- **README.md -** Adding the Codacy Badges that get updated after each pull/push. One is for code coverage, the other is for quality. The Badges will need to be adjusted once Codacy is set up for this repo, as right now it still points to my local fork.



**Explanation:**

During the running of pytest, coverage.py will monitor how much of the code base is ran by each individual test.
After the tests run, the code coverage results are then forwarded to Codacy, where it'll provide the badge with the test coverage percentage.
To forward the results to Codacy, Codacy provides you with an authentication token for your project. 
We store this authentication token as sensitive credentials for Github worklows via Repository Secrets under the repo's Settings tab. 
This repo secret is referred to in the pytest workflow as $ {{ secret.CODACY_PROJECT_TOKEN }}




I wanted this pull request to be as easy as approving it, merging it and moving on.  
But unfortunately because of the privilege issues, two steps need to be taken by the administrator. This is why I had to fork the repo again.

- First is installing Codacy into the repo. 
- Afterwards, supplying the authentication token for the workflow to use by adding a new Repository Secret in the Settings. 



