### PR TITLE
fix mypy issues

### DIFF
--- a/agents/MaliciousPublisherAgent.py
+++ b/agents/MaliciousPublisherAgent.py
@@ -4,8 +4,8 @@ from typing import List
 from agents import PublisherAgent
 
 #magic numbers
-DEFAULT_s_wait_to_rug = PublisherAgent.DEFAULT_s_between_create/2
-DEFAULT_s_rug_time = DEFAULT_s_wait_to_rug/5
+DEFAULT_s_wait_to_rug = int(PublisherAgent.DEFAULT_s_between_create/2)
+DEFAULT_s_rug_time = int(DEFAULT_s_wait_to_rug/5)
 PERCENT_UNSTAKE = 0.20
 
 @enforce_types


### PR DESCRIPTION
Towards #96. Issues were:
agents/MaliciousPublisherAgent.py:25: error: Incompatible default for argument "s_wait_to_rug" (default has type "float", argument has type "int")
agents/MaliciousPublisherAgent.py:26: error: Incompatible default for argument "s_rug_time" (default has type "float", argument has type "int")