### PR TITLE
Issue 103 - 51% scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,4 +277,4 @@ Art:
 
 The license is MIT. [Details](LICENSE)
 
-<img src="images/fishnado2-crop.jpeg" width="100%">
+<img src="images/fishnado2-crop.jpeg" width="100%"> 

--- a/sol080/contracts/scheduler080/VestingWallet080.sol
+++ b/sol080/contracts/scheduler080/VestingWallet080.sol
@@ -24,21 +24,21 @@ contract VestingWallet080 is Context {
     uint256 private _released;
     mapping(address => uint256) private _erc20Released;
     address private immutable _beneficiary;
-    uint64 private immutable _start;
-    uint64 private immutable _duration;
+    uint256 private immutable _startBlock;
+    uint256 private immutable _numBlocksDuration;
 
     /**
-     * @dev Set the beneficiary, start timestamp and vesting duration of the vesting wallet.
+     * @dev Set the beneficiary, start blockNumber and vesting duration of the vesting wallet.
      */
     constructor(
         address beneficiaryAddress,
-        uint64 startTimestamp,
-        uint64 durationSeconds
+        uint256 startBlock,
+        uint256 numBlocksDuration
     ) {
         require(beneficiaryAddress != address(0), "VestingWallet080: beneficiary is zero address");
         _beneficiary = beneficiaryAddress;
-        _start = startTimestamp;
-        _duration = durationSeconds;
+        _startBlock = startBlock;
+        _numBlocksDuration = numBlocksDuration;
     }
 
     /**
@@ -54,17 +54,17 @@ contract VestingWallet080 is Context {
     }
 
     /**
-     * @dev Getter for the start timestamp.
+     * @dev Getter for the start blockNumber.
      */
-    function start() public view virtual returns (uint256) {
-        return _start;
+    function startBlock() public view virtual returns (uint256) {
+        return _startBlock;
     }
 
     /**
      * @dev Getter for the vesting duration.
      */
-    function duration() public view virtual returns (uint256) {
-        return _duration;
+    function numBlocksDuration() public view virtual returns (uint256) {
+        return _numBlocksDuration;
     }
 
     /**
@@ -87,7 +87,7 @@ contract VestingWallet080 is Context {
      * Emits a {TokensReleased} event.
      */
     function release() public virtual {
-        uint256 releasable = vestedAmount(uint64(block.timestamp)) - released();
+        uint256 releasable = vestedAmount(uint256(block.number*10**18)) - released();
         _released += releasable;
         emit EtherReleased(releasable);
         Address.sendValue(payable(beneficiary()), releasable);
@@ -99,7 +99,7 @@ contract VestingWallet080 is Context {
      * Emits a {TokensReleased} event.
      */
     function release(address token) public virtual {
-        uint256 releasable = vestedAmount(token, uint64(block.timestamp)) - released(token);
+        uint256 releasable = vestedAmount(token, uint256(block.number*10**18)) - released(token);
         _erc20Released[token] += releasable;
         emit ERC20Released(token, releasable);
         SafeERC20.safeTransfer(IERC20(token), beneficiary(), releasable);
@@ -108,28 +108,28 @@ contract VestingWallet080 is Context {
     /**
      * @dev Calculates the amount of ether that has already vested. Default implementation is a linear vesting curve.
      */
-    function vestedAmount(uint64 timestamp) public view virtual returns (uint256) {
-        return _vestingSchedule(address(this).balance + released(), timestamp);
+    function vestedAmount(uint256 blockNumber) public view virtual returns (uint256) {
+        return _vestingSchedule(address(this).balance + released(), blockNumber);
     }
 
     /**
      * @dev Calculates the amount of tokens that has already vested. Default implementation is a linear vesting curve.
      */
-    function vestedAmount(address token, uint64 timestamp) public view virtual returns (uint256) {
-        return _vestingSchedule(IERC20(token).balanceOf(address(this)) + released(token), timestamp);
+    function vestedAmount(address token, uint256 blockNumber) public view virtual returns (uint256) {
+        return _vestingSchedule(IERC20(token).balanceOf(address(this)) + released(token), blockNumber);
     }
 
     /**
      * @dev Virtual implementation of the vesting formula. This returns the amout vested, as a function of time, for
      * an asset given its total historical allocation.
      */
-    function _vestingSchedule(uint256 totalAllocation, uint64 timestamp) internal view virtual returns (uint256) {
-        if (timestamp < start()) {
+    function _vestingSchedule(uint256 totalAllocation, uint256 blockNumber) internal view virtual returns (uint256) {
+        if (blockNumber < startBlock()) {
             return 0;
-        } else if (timestamp > start() + duration()) {
+        } else if (blockNumber > (startBlock() + numBlocksDuration())) {
             return totalAllocation;
         } else {
-            return (totalAllocation * (timestamp - start())) / duration();
+            return ( totalAllocation * (blockNumber - startBlock()) / numBlocksDuration());
         }
     }
 }

--- a/sol080/contracts/scheduler080/test/test_VestingWallet080.py
+++ b/sol080/contracts/scheduler080/test/test_VestingWallet080.py
@@ -80,7 +80,6 @@ def test_ethFunding():
     # make enough time pass for everything to vest
     chain.mine(blocks=14, timedelta=100)
 
-    #what I want 
     assert wallet.vestedAmount(toBase18(1)) == 0
     assert wallet.vestedAmount(toBase18(2)) == 0
     assert wallet.vestedAmount(toBase18(3)) == 0

--- a/sol080/contracts/scheduler080/test/test_VestingWallet080.py
+++ b/sol080/contracts/scheduler080/test/test_VestingWallet080.py
@@ -17,6 +17,7 @@ chain = brownie.network.chain
 
 
 def test_basic():
+    n_blocks = len(chain)
     beneficiary = address1
     start_block = n_blocks + 1
     num_blocks_duration = 4

--- a/sol080/contracts/scheduler080/test/test_VestingWallet080.py
+++ b/sol080/contracts/scheduler080/test/test_VestingWallet080.py
@@ -79,22 +79,6 @@ def test_ethFunding():
 
     # make enough time pass for everything to vest
     chain.mine(blocks=14, timedelta=100)
-    """what I get
-
-    (Pdb) for i in range(11): print(f"i={i}, vested={wallet.vestedAmount(toBase18(i))}")
-    i=0, vested=0
-    i=1, vested=0
-    i=2, vested=0
-    i=3, vested=0
-    i=4, vested=0
-    i=5, vested=0
-    i=6, vested=0
-    i=7, vested=0
-    i=8, vested=0
-    i=9, vested=30000000000000000000
-    i=10, vested=30000000000000000000
-
-    """
 
     #what I want 
     assert wallet.vestedAmount(toBase18(1)) == 0


### PR DESCRIPTION
Towards #103 : 
- Fix scheduler bug: fails on y2038 problem. Possible solution: leverage block count more, timestamp less
- Use slightly less verbose "account2" instead of "accounts[2]", etc. 